### PR TITLE
Fix: unterminated string literal in cli.py (line 980)

### DIFF
--- a/src/HaplotagLR/cli.py
+++ b/src/HaplotagLR/cli.py
@@ -977,7 +977,7 @@ def getArgs() -> object:
         required = False,
         default = False,
         action = 'store_true',
-        help = "Obtain the sequencing error rate, epsilon, as per-base observed error rates, calculated directly from Phred scores in each BAM record. By default, the gap-compressed per-base divergence rate for each read will be used. These are given directly in minimap2 under the 'de' tag, or calculated from the pbmm2 'mg' tag as (100-mg)/100. Superseded by --global_epsilon.
+        help = "Obtain the sequencing error rate, epsilon, as per-base observed error rates, calculated directly from Phred scores in each BAM record. By default, the gap-compressed per-base divergence rate for each read will be used. These are given directly in minimap2 under the 'de' tag, or calculated from the pbmm2 'mg' tag as (100-mg)/100. Superseded by --global_epsilon."
 
     )
 


### PR DESCRIPTION
I was trying to run HaplotagLR and encountered a syntax error:

`File "/home/wjhlang/anaconda3/envs/HaplotagLR_env/lib/python3.12/site-packages/HaplotagLR/cli.py", line 980
    help = "Obtain the sequencing error rate, epsilon, as per-base observed error rates, calculated directly from Phred scores in each BAM record. By default, the gap-compressed per-base divergence rate for each read will be used. These are given directly in minimap2 under the 'de' tag, or calculated from the pbmm2 'mg' tag as (100-mg)/100. Superseded by --global_epsilon.
           ^
SyntaxError: unterminated string literal (detected at line 980)`

### Fix
Add the closing quote to close the string